### PR TITLE
Add simple web UI with Supabase integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,34 @@ A simple command-line tool to help you track your habits.
 
 ## Usage
 
-```
+```bash
 python src/habit_tracker.py add "Exercise"
 python src/habit_tracker.py list
 ```
 
 Habits are stored in `~/.habit_tracker.json`.
+
+## Web UI
+
+A minimal web interface is available that stores habits in a Supabase table named `habits`.
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set your Supabase credentials:
+
+```bash
+export SUPABASE_URL=<your supabase url>
+export SUPABASE_KEY=<your service role or anon key>
+```
+
+3. Run the application:
+
+```bash
+python src/habit_tracker_web.py
+```
+
+The app will start a local Flask server. Visit `http://localhost:5000` to add and view habits.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.1.1
+supabase==2.15.2

--- a/src/habit_tracker_web.py
+++ b/src/habit_tracker_web.py
@@ -1,0 +1,43 @@
+import os
+from flask import Flask, render_template_string, request, redirect, url_for
+from supabase import create_client, Client
+
+SUPABASE_URL = os.getenv('SUPABASE_URL')
+SUPABASE_KEY = os.getenv('SUPABASE_KEY')
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    raise RuntimeError('SUPABASE_URL and SUPABASE_KEY environment variables must be set')
+
+supabase: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+app = Flask(__name__)
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        habit_name = request.form.get('name')
+        if habit_name:
+            supabase.table('habits').insert({'name': habit_name}).execute()
+        return redirect(url_for('index'))
+
+    response = supabase.table('habits').select('name').execute()
+    habits = [item['name'] for item in response.data] if response.data else []
+
+    html = '''
+    <h1>Habit Tracker</h1>
+    <form method="post">
+        <input type="text" name="name" placeholder="New Habit" required>
+        <button type="submit">Add Habit</button>
+    </form>
+    <ul>
+    {% for habit in habits %}
+        <li>{{ habit }}</li>
+    {% endfor %}
+    </ul>
+    '''
+    return render_template_string(html, habits=habits)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- document new Supabase-backed web interface
- create Flask UI that reads/writes habits to Supabase
- list Flask and Supabase requirements

## Testing
- `python -m py_compile src/habit_tracker.py src/habit_tracker_web.py`

------
https://chatgpt.com/codex/tasks/task_e_6840e4661c48832b9f12425b3e24d631